### PR TITLE
Add missing brands enpoints

### DIFF
--- a/backend/controllers/brand_controller.py
+++ b/backend/controllers/brand_controller.py
@@ -6,6 +6,7 @@ from models.brand import (
     insert_brand,
     get_products_by_brand,
     activate_brand_by_id,
+    update_brand,
 )
 
 
@@ -104,3 +105,11 @@ def insert_brand_controller():
         name
     )  # Llama a insert_brand pasando solo el nombre
     return jsonify(response), status_code  # Devuelve la respuesta como JSON
+
+
+def update_brand_controller(id_brand, data):
+    response = update_brand(id_brand, data)
+    if response:
+        return jsonify({"message": "brand updated"}), 200
+    else:
+        return jsonify(response), 500

--- a/backend/controllers/brand_controller.py
+++ b/backend/controllers/brand_controller.py
@@ -3,6 +3,7 @@ from models.brand import (
     get_brands,
     get_brands_by_id,
     delete_brand_by_id,
+    get_inactive_brands,
     insert_brand,
     get_products_by_brand,
     activate_brand_by_id,
@@ -113,3 +114,10 @@ def update_brand_controller(id_brand, data):
         return jsonify({"message": "brand updated"}), 200
     else:
         return jsonify(response), 500
+
+
+def get_inactive_brands_controller():
+    response = get_inactive_brands()
+    if not response:
+        return jsonify({"message": "There's no deleted brands"}), 200
+    return jsonify(response), 200

--- a/backend/models/brand.py
+++ b/backend/models/brand.py
@@ -164,3 +164,27 @@ def get_products_by_brand(id_brand):
 
     except Exception as e:
         return False, str(e)  # Manejo de errores
+
+
+def update_brand(id_brand, data):
+    try:
+        conn = get_connection()
+        if conn:
+            cursor = conn.cursor(MySQLdb.cursors.DictCursor)
+            sql = """
+                UPDATE brand 
+                SET name = %s 
+                WHERE id_brand = %s AND is_active=1
+            """
+            values = (
+                data.get("name"),
+                id_brand,
+            )
+            cursor.execute(sql, values)
+            conn.commit()
+            affected = cursor.rowcount
+            cursor.close()
+            conn.close()
+            return affected > 0
+    except MySQLdb.Error as e:
+        return False, e

--- a/backend/models/brand.py
+++ b/backend/models/brand.py
@@ -188,3 +188,17 @@ def update_brand(id_brand, data):
             return affected > 0
     except MySQLdb.Error as e:
         return False, e
+
+
+def get_inactive_brands():
+    try:
+        conn = get_connection()
+        if conn:
+            cursor = conn.cursor(MySQLdb.cursors.DictCursor)
+            cursor.execute("SELECT * FROM type_product WHERE is_active = 0")
+            brands = cursor.fetchall()
+            cursor.close()
+            conn.close()
+            return brands
+    except MySQLdb.Error as e:
+        return False, e

--- a/backend/routes/catalog.py
+++ b/backend/routes/catalog.py
@@ -10,6 +10,7 @@ from controllers.brand_controller import (
     get_brands_controller,
     get_brands_by_id_controller,
     delete_brand_controller,
+    get_inactive_brands_controller,
     get_products_by_brand_controller,
     insert_brand_controller,
     activate_brand_controller,
@@ -115,6 +116,11 @@ def get_brands():
         jsonify(response),
         status_code,
     )  # Llama al controlador para obtener todas las marcas
+
+
+@catalog_bp.route("/brand/inactive", methods=["GET"])
+def get_inactive_brands():
+    return get_inactive_brands_controller()
 
 
 @catalog_bp.route("/brand/<int:id_brand>", methods=["GET"])

--- a/backend/routes/catalog.py
+++ b/backend/routes/catalog.py
@@ -13,6 +13,7 @@ from controllers.brand_controller import (
     get_products_by_brand_controller,
     insert_brand_controller,
     activate_brand_controller,
+    update_brand_controller,
 )
 from controllers.product_controller import (
     get_all_products_controller,
@@ -152,6 +153,12 @@ def get_products_by_brand(id_brand):
         jsonify(response),
         status_code,
     )  # Llama al controlador para obtener productos por marca
+
+
+@catalog_bp.route("/brand/<int:id_brand>", methods=["PUT"])
+def update_brand(id_brand):
+    data = request.get_json()
+    return update_brand_controller(id_brand, data)
 
 
 # * ROUTES FOR TYPE PRODUCTS


### PR DESCRIPTION
### Objetivo: 
Este PR complementa algunos endpoints que faltaban en catalog/brands

### 🛠️ Cambios principales
1. models (brand.py)

    - Se añade una consulta a la base de datos para actualizar los campos de una marca
    - Se añade una consulta a la base de datos para listar marcas eliminadas

2. routes (catalog.py)

    - Endpoints

      - `GET /brand/inactive` listar las marcas eliminadas
      - `PUT /brand/<int:id_brand>` Actualizar una marca por id

### 📝 Notas

- Posible refactorización para metodos como `insert_brand` para mejorar la estructura del código

Esta implementación fue realizada por @sjulian25 .